### PR TITLE
feat: cache homebrew deps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,7 +81,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+      uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
       with:
         languages: ${{ matrix.language }}
 
@@ -93,4 +93,4 @@ jobs:
         cmake --build build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+      uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -274,7 +274,7 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -43,17 +43,75 @@ jobs:
       - name: Setup build environment - non-release
         if: ${{ !inputs.release }}
         run: |
+          echo "BREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           brew uninstall cmake # conflict with the one used by WasmEdge/llvm/lld
           brew tap WasmEdge/llvm
+      - name: Install Homebrew tools - non-release
+        if: ${{ !inputs.release }}
+        run: |
           brew install llvm ninja wabt grpc
-          brew install --build-from-source WasmEdge/llvm/lld
+      - name: Get lld version
+        if: ${{ !inputs.release }}
+        id: lld-version-non-release
+        run: |
+          VERSION=$(brew info --json WasmEdge/llvm/lld | jq -r '.[0].versions.stable')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Cache lld and cmake - non-release
+        if: ${{ !inputs.release }}
+        id: cache-lld-non-release
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ env.BREW_PREFIX }}/Cellar/lld
+            ${{ env.BREW_PREFIX }}/Cellar/cmake
+          key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
+          restore-keys: |
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
+      - name: Install or link lld and cmake - non-release
+        if: ${{ !inputs.release }}
+        run: |
+          if [ "${{ steps.cache-lld-non-release.outputs.cache-hit }}" != "true" ]; then
+            brew install --build-from-source WasmEdge/llvm/lld
+          fi
+          brew link lld || true
+          brew link cmake || true
       - name: Setup build environment - release
         if: ${{ inputs.release }}
         run: |
+          echo "BREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           brew uninstall cmake # conflict with the one used by WasmEdge/llvm/lld
           brew tap WasmEdge/llvm
+      - name: Install Homebrew tools - release
+        if: ${{ inputs.release }}
+        run: |
           brew install llvm ninja wabt
-          brew install --build-from-source WasmEdge/llvm/lld
+      - name: Get lld version
+        if: ${{ inputs.release }}
+        id: lld-version-release
+        run: |
+          VERSION=$(brew info --json WasmEdge/llvm/lld | jq -r '.[0].versions.stable')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Cache lld and cmake - release
+        if: ${{ inputs.release }}
+        id: cache-lld-release
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ env.BREW_PREFIX }}/Cellar/lld
+            ${{ env.BREW_PREFIX }}/Cellar/cmake
+          key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
+          restore-keys: |
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
+      - name: Install or link lld and cmake - release
+        if: ${{ inputs.release }}
+        run: |
+          if [ "${{ steps.cache-lld-release.outputs.cache-hit }}" != "true" ]; then
+            brew install --build-from-source WasmEdge/llvm/lld
+          fi
+          brew link lld || true
+          brew link cmake || true
       - name: Set environment variables for release
         if: ${{ inputs.release }}
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS build pipeline with architecture-aware Homebrew handling for more reliable macOS CI.
  * Split non-release and release workflows to install Homebrew tools via reusable steps for consistency.
  * Added caching and conditional install/linking for native toolchain components to speed up CI and reduce redundant work.
  * Updated security and tooling actions to newer versions for improved analysis and container workflow reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phantominthewire/wasmedge/pull/4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
